### PR TITLE
Control DNS for infra nodes in terraform.

### DIFF
--- a/static/cloud-init/stratum1-eu-west.eessi-hpc.org.yaml
+++ b/static/cloud-init/stratum1-eu-west.eessi-hpc.org.yaml
@@ -1,0 +1,43 @@
+#cloud-config
+
+# Cloud-init for login.eessi-hpc.org
+
+#fs_setup:
+#    - device: /dev/nvme1n1
+#      partition: none
+#      label: eessi-home
+#      filesystem: ext4
+#      overwrite: false
+
+hostname: stratum1-eu-west.eessi-hpc.org
+
+mounts:
+    - [ "LABEL=stratum1-e-w", "/stratum1" ]
+
+yum_repos:
+    epel-release:
+        baseurl: https://download.fedoraproject.org/pub/epel/$releasever/Everything/$basearch
+        metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+        enabled: true
+        failovermethod: priority
+        gpgcheck: true
+        gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+        name: Extra Packages for Enterprise Linux 8 - Release
+
+package_upgrade: true
+
+packages:
+  - ansible
+  - awscli  
+  - git
+  - httpd
+  - htop
+  # required for semanage
+  - policycoreutils-python-utils
+  - python38
+  - screen
+  - singularity
+  - tmux
+
+runcmd:
+  - semanage fcontext -a -e /var/www /stratum1

--- a/static/terraform/login.tf
+++ b/static/terraform/login.tf
@@ -17,6 +17,10 @@ resource "aws_instance" "login_node" {
     volume_size = 20
   }
 
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+
   tags = {
 #    Owner = var.localuser
     Name = "[CORE] login.eessi-hpc.org"
@@ -39,6 +43,10 @@ resource "aws_instance" "login_node" {
 resource "aws_eip" "login_node" {
   instance = aws_instance.login_node.id
   vpc      = true
+
+  tags = {
+    Name = "login"
+  }
 }
 
 resource "aws_volume_attachment" "home-attachment" {
@@ -47,4 +55,12 @@ resource "aws_volume_attachment" "home-attachment" {
   volume_id    = "vol-0002925059d439a40"
   instance_id  = aws_instance.login_node.id
   force_detach = true
+}
+
+resource "aws_route53_record" "login" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "login.infra.eessi-hpc.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.login_node.public_ip]
 }

--- a/static/terraform/stratum1-eu-west.tf
+++ b/static/terraform/stratum1-eu-west.tf
@@ -17,6 +17,9 @@ resource "aws_instance" "stratum1_eu_west" {
     volume_size = 20
   }
 
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
   tags = {
 #    Owner = var.localuser
     Name = "[CORE] stratum1-eu-west.eessi-hpc.org"
@@ -26,6 +29,11 @@ resource "aws_instance" "stratum1_eu_west" {
 resource "aws_eip" "stratum1_eu_west" {
   instance = aws_instance.stratum1_eu_west.id
   vpc      = true
+
+  tags = {
+    Name = "stratum1-eu-west"
+  }
+
 }
 
 resource "aws_volume_attachment" "stratum1_eu_west_attachment" {
@@ -34,4 +42,12 @@ resource "aws_volume_attachment" "stratum1_eu_west_attachment" {
   volume_id    = "vol-0f85254bbd75761f4"
   instance_id  = aws_instance.stratum1_eu_west.id
   force_detach = true
+}
+
+resource "aws_route53_record" "stratum1_eu_west" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "cvmfs-s1-aws-euwest1.infra.eessi-hpc.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.stratum1_eu_west.public_ip]
 }

--- a/static/terraform/variables.tf
+++ b/static/terraform/variables.tf
@@ -6,6 +6,9 @@ variable "aws_availability_zone" {
   default = "eu-west-1a"
 }
 
+variable "aws_route53_infra_zoneid" {
+  default = "Z10412033IZUH86YLABLW"
+}
 variable "localuser" {
   default = "eessi-admin"
 }


### PR DESCRIPTION
  - Also ignore ami and user_script changes with looking at
    reprovisioning the login and stratum1 nodes. This prevents
    these nodes from being destroyed and rebuilt every time we
    create a new ami.
  - Oh, and the stratum1 cloud init file was missing...