### PR TITLE
Add eessi-infra.org as a supported domain.

### DIFF
--- a/static/terraform/login.tf
+++ b/static/terraform/login.tf
@@ -59,6 +59,13 @@ resource "aws_volume_attachment" "home-attachment" {
 
 resource "aws_route53_record" "login" {
   zone_id = var.aws_route53_infra_zoneid
+  name    = "login.eessi-infra.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.login_node.public_ip]
+}
+resource "aws_route53_record" "login_infra" {
+  zone_id = var.aws_route53_infra_hpc_zoneid
   name    = "login.infra.eessi-hpc.org"
   type    = "A"
   ttl     = "300"

--- a/static/terraform/stratum1-eu-west.tf
+++ b/static/terraform/stratum1-eu-west.tf
@@ -45,8 +45,15 @@ resource "aws_volume_attachment" "stratum1_eu_west_attachment" {
 }
 
 resource "aws_route53_record" "stratum1_eu_west" {
-  zone_id = var.aws_route53_infra_zoneid
+  zone_id = var.aws_route53_infra_hpc_zoneid
   name    = "cvmfs-s1-aws-euwest1.infra.eessi-hpc.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.stratum1_eu_west.public_ip]
+}
+resource "aws_route53_record" "stratum1_eu_west_infra" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "cvmfs-s1-aws-euwest1.eessi-infra.org"
   type    = "A"
   ttl     = "300"
   records = [aws_eip.stratum1_eu_west.public_ip]

--- a/static/terraform/variables.tf
+++ b/static/terraform/variables.tf
@@ -6,9 +6,14 @@ variable "aws_availability_zone" {
   default = "eu-west-1a"
 }
 
-variable "aws_route53_infra_zoneid" {
+variable "aws_route53_infra_hpc_zoneid" {
   default = "Z10412033IZUH86YLABLW"
 }
+
+variable "aws_route53_infra_zoneid" {
+  default = "Z08669212W005E4G61IF8"
+}
+
 variable "localuser" {
   default = "eessi-admin"
 }


### PR DESCRIPTION
  - Nodes now use both domains as default.