### PR TITLE
Add monitoring server.

### DIFF
--- a/static/cloud-init/monitoring.eessi-hpc.org.yaml
+++ b/static/cloud-init/monitoring.eessi-hpc.org.yaml
@@ -1,0 +1,46 @@
+#cloud-config
+
+# Cloud-init for login.eessi-hpc.org
+
+#fs_setup:
+#    - device: /dev/nvme1n1
+#      partition: none
+#      label: eessi-home
+#      filesystem: ext4
+#      overwrite: false
+
+hostname: monitoring.eessi-hpc.org
+
+mounts:
+    - [ "/dev/shd", "/persistent" ]
+
+yum_repos:
+    epel-release:
+        baseurl: https://download.fedoraproject.org/pub/epel/$releasever/Everything/$basearch
+        metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+        enabled: true
+        failovermethod: priority
+        gpgcheck: true
+        gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+        name: Extra Packages for Enterprise Linux 8 - Release
+
+package_upgrade: true
+
+packages:
+  - ansible
+  - awscli  
+  - git
+  - htop
+  # required for semanage
+  - policycoreutils-python-utils
+  - python38
+  - screen
+  - singularity
+  - tmux
+  - zabbix
+  - grafana
+  - grafana-prometheus
+
+# From where do we copy permissions? Need to look at sealert.
+#runcmd:
+#  - semanage fcontext -a -e /var /persistent

--- a/static/terraform/monitoring.tf
+++ b/static/terraform/monitoring.tf
@@ -1,0 +1,61 @@
+data "template_file" "monitoring_user_data" {
+  template = file("../cloud-init/monitoring.eessi-hpc.org.yaml")
+}
+
+resource "aws_instance" "monitoring_node" {
+#  depends_on             = [aws_ebs_volume.home_volume]
+
+  ami                    = data.aws_ami.x86_64.id
+  instance_type          = var.instance_monitoring
+  vpc_security_group_ids = [aws_security_group.open_web_node.id]
+  key_name               = "${var.localuser}-core-deployer-key"
+  monitoring             = true
+  availability_zone      = "eu-west-1a"
+  user_data              = data.template_file.monitoring_user_data.rendered
+
+  root_block_device {
+    volume_size = 20
+  }
+
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+
+  tags = {
+#    Owner = var.localuser
+    Name = "[CORE] monitoring.infra.eessi-hpc.org"
+  }
+}
+
+resource "aws_volume_attachment" "monitoring-attachment" {
+  depends_on   = [aws_instance.monitoring_node]
+  device_name  = "/dev/sdh"
+  volume_id    = aws_ebs_volume.monitoring_persistent_volume.id
+  instance_id  = aws_instance.monitoring_node.id
+  force_detach = true
+}
+
+
+resource "aws_eip" "monitoring_node" {
+  instance = aws_instance.monitoring_node.id
+  vpc      = true
+
+  tags = {
+    Name = "monitoring"
+  }
+}
+
+resource "aws_route53_record" "monitoring" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "monitoring.eessi-infra.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.monitoring_node.public_ip]
+}
+resource "aws_route53_record" "monitoring_infra" {
+  zone_id = var.aws_route53_infra_hpc_zoneid
+  name    = "monitoring.infra.eessi-hpc.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.monitoring_node.public_ip]
+}

--- a/static/terraform/output.tf
+++ b/static/terraform/output.tf
@@ -14,3 +14,7 @@ output "stratum1_eu_west_node_eip" {
   value       = aws_eip.stratum1_eu_west.*.public_dns
 }
 
+output "monitoring_node_eip" {
+  value       = aws_eip.monitoring_node.*.public_dns
+}
+

--- a/static/terraform/security.tf
+++ b/static/terraform/security.tf
@@ -27,6 +27,38 @@ resource "aws_security_group" "open_node" {
   }
 }
 
+resource "aws_security_group" "open_web_node" {
+  name = "open-web-node"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
 resource "aws_security_group" "stratum1" {
   name = "stratum1"
   ingress {

--- a/static/terraform/variables.tf
+++ b/static/terraform/variables.tf
@@ -40,6 +40,10 @@ variable "instance_stratum1" {
     default = "t3.xlarge"
 }
 
+variable "instance_monitoring" {
+    default = "t3.xlarge"
+}
+
 variable "instance_login" {
     default = "t4g.micro"
 }

--- a/static/terraform/volumes.tf
+++ b/static/terraform/volumes.tf
@@ -1,0 +1,12 @@
+resource "aws_ebs_volume" "monitoring_persistent_volume" {
+  availability_zone = "eu-west-1a"
+  size = 50
+
+  tags = {
+    Name = "Monitoring : Data volume"
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}


### PR DESCRIPTION
  - Adds monitoring.infra.eessi-hpc.org aka monitoring.eessi-infra.org.
  - Adds a security group that allows port 443.
  - Adds a backend volume for monitoring data.
  - Adds a cloud-init file for the node to preinstall monitoring
    software.