### PR TITLE
Use iam roles for nodes and aws for uploading

### DIFF
--- a/dynamic/eessi-dynamic
+++ b/dynamic/eessi-dynamic
@@ -77,6 +77,8 @@ def main():
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
     parser.add_argument('--create-node', dest='node_type',
                         help='Node type for the VM. (arch[:size][:provider]|instance_type)')
+    parser.add_argument('--node-storage', dest="node_storage",
+                        help='Root volume size for the node. 50GB is the recommended default.')
     parser.add_argument('--node-name', dest="node_name",
                         help='DNS name for the node.')
     parser.add_argument('--node-description', dest="node_description",
@@ -146,6 +148,9 @@ def main():
             "description": silly_name,
             "name": silly_name,
             "issuer": os.environ['LOGNAME'],
+            "terraform_directory": TERRAFORM_DIRECTORY,
+            "template_directory": os.getcwd() + '/' + TEMPLATE_DIRECTORY,
+            "storage": 50,
             "username": '',
             "userslack": '',
             "eol": datetime.datetime.now() + datetime.timedelta(days=7),

--- a/dynamic/templates/keys.j2
+++ b/dynamic/templates/keys.j2
@@ -14,4 +14,9 @@ resource "aws_key_pair" "{{ deployer_id }}-keys" {
   tags = {
     Owner = "{{ deployer_id }}"
   }
+
+  lifecycle {
+    ignore_changes = all
+  }
+
 }

--- a/dynamic/templates/node.j2
+++ b/dynamic/templates/node.j2
@@ -6,7 +6,10 @@ resource "{{ provider }}_instance" "{{ name }}" {
   ami                    = data.aws_ami.aarch64.id
   {%- endif %}
   provider               = eessiaws
-  
+
+
+
+
   ipv6_address_count     = 1
 {%- endif %}
 
@@ -22,16 +25,37 @@ resource "{{ provider }}_instance" "{{ name }}" {
   monitoring             = true
 
   root_block_device {
-    volume_size = 50
+    volume_size = {{ storage }}
   }
 
   tags = {
     Issuer = "{{ issuer }}"
-    Name  = "{{ description }}"
+    Name  = "{{ name }}"
     User  = "{{ username }}"
     Slack = "{{ userslack }}"
     EOL = "{{ eol }}"
     Ephemeral = "True"
+  }
+
+  provisioner "file" {
+    destination = "/tmp/provision.sh"
+    content = templatefile("{{ template_directory }}/node_data.j2", {
+        issuer = "{{ issuer }}"
+        user = "{{ username }}"
+        slack_user = "{{ userslack }}"
+        node_name = "{{ name }}"
+        aws_access_key_id = aws_iam_access_key.{{ name }}.id
+        aws_secret_access_key = aws_iam_access_key.{{ name }}.secret
+    })
+  }
+
+  provisioner "remote-exec" {
+    inline = ["sh /tmp/provision.sh"]
+  }
+
+  connection {
+    host = self.public_ip
+    user = "eessi"
   }
 }
 
@@ -51,4 +75,53 @@ resource "aws_route53_record" "{{ name }}" {
   type     = "A"
   ttl      = "300"
   records  = [{{ provider}}_instance.{{ name }}.public_ip]
+}
+
+resource "aws_iam_user" "{{ name }}" {
+  provider = eessiaws
+
+  name = "node_user_{{ name }}"
+  path = "/generated/"
+
+  tags = {
+    Managed = "terraform"
+    Name = "IAM user for the node {{ name }}"
+  }
+}
+
+resource "aws_iam_user_policy" "{{ name }}" {
+  provider = eessiaws
+
+  name = "node_user_policy_{{ name }}"
+  user = aws_iam_user.{{ name }}.name
+
+  # Terraform's "jsonencode" function converts a
+  # Terraform expression result to valid JSON syntax.
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "s3:ListBucket",
+          "s3:GetObject",
+          "s3:GetObjectVersion",
+          "s3:GetBucketLocation",
+          "s3:PutObject",
+          "s3:PutObjectAcl",
+        ]
+        Effect = "Allow"
+        Resource = [
+          "arn:aws:s3:::eessi-staging",
+          "arn:aws:s3:::eessi-staging/*",
+        ]
+      },
+    ]
+  })
+}
+
+
+
+resource "aws_iam_access_key" "{{ name }}" {
+  provider = eessiaws
+  user = aws_iam_user.{{ name }}.name
 }

--- a/dynamic/templates/node_data.j2
+++ b/dynamic/templates/node_data.j2
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cat << EOF > /tmp/.meta
+issuer: ${ issuer }
+user: ${ user }
+slack_user: ${ slack_user }
+EOF
+
+sudo mv /tmp/.meta /home/eessi/.meta
+
+sudo mkdir /home/eessi/.aws
+cat << EOF > /tmp/.credentials
+[default]
+aws_access_key_id = ${ aws_access_key_id }
+aws_secret_access_key = ${aws_secret_access_key }
+EOF
+sudo mv /tmp/.credentials /home/eessi/.aws/credentials
+
+sudo chown -R eessi:eessi /home/eessi/.meta /home/eessi/.aws
+sudo chmod 0700 /home/eessi/.aws
+sudo chmod -R 0600 /home/eessi/.meta /home/eessi/.aws/*
+
+sudo userdel -r ec2-user

--- a/eessi-upload-to-staging
+++ b/eessi-upload-to-staging
@@ -7,38 +7,9 @@ fi
 
 function upload_to_staging_bucket
 {
-  file=$1
-  path=$2
+  path=$1
   bucket='eessi-staging'
-  region='eu-west-1'
-  date=$(date +"%a, %d %b %Y %T %z")
-  content_type='application/x-compressed-tar'
-
-  acl="x-amz-acl:private"
-  string="PUT\n\n${content_type}\n${date}\n${acl}\n/${bucket}/${path}"
-  
-  if ! [ -z "$AWS_ACCESS_KEY_ID" ]; then
-    signature=$(echo -en "${string}" | openssl sha1 -hmac "${AWS_SECRET_ACCESS_KEY}" -binary | base64)
-    authstring="-H \"Authorization: AWS ${AWS_SECRET_ACCESS_KEY}:$signature\""
-    aclstring="-H \"${acl}\""
-  fi
-
-  echo "Attempting to create: https://${bucket}.s3.amazonaws.com/${path}"
-  if type -a aws > /dev/null; then
-    OPTIONS=""
-    if [ -z "$AWS_ACCESS_KEY_ID"]; then
-      OPTIONS="--no-sign-request"
-    fi
-    aws ${OPTIONS} s3 cp "$file" s3://${bucket}/${path}
-  else
-  curl -X PUT -T "$file" \
-    -H "Host: ${bucket}.s3.amazonaws.com" \
-    -H "Date: ${date}" \
-    -H "Content-Type: ${content_type}" \
-    $aclstring \
-    $authstring \
-    "https://${bucket}.s3.amazonaws.com/${path}"
-  fi
+  aws ${OPTIONS} s3 cp "$file" s3://${bucket}/${path}
 }
 
 # This needs expanding etc.
@@ -58,10 +29,10 @@ for file in "$*"; do
   if [[ -r "$file" && -f "$file" &&  -s "$file" ]]; then
     basefile=$( basename $file )
     if check_file_name $basefile; then
-      if tar tf "$file" > /dev/null; then
+      if tar tf "$file" | head -n1 > /dev/null; then
         aws_path=$(basename $file | tr -s '-' '/' | perl -pe 's/^eessi.//;')
         echo $aws_path
-        upload_to_staging_bucket "${file}" "${aws_path}"
+        upload_to_staging_bucket "${aws_path}"
       else
         echo "'$file' is not a tar file."
         exit 1

--- a/eessi-upload-to-staging
+++ b/eessi-upload-to-staging
@@ -57,7 +57,7 @@ for file in "$*"; do
       if tar tf "$file" > /dev/null; then
         aws_path=$(basename $file | tr -s '-' '/' | perl -pe 's/^eessi.//;')
         echo $aws_path
-#       upload_to_staging_bucket "${file}" "${aws_path}"
+        upload_to_staging_bucket "${file}" "${aws_path}"
       else
         echo "'$file' is not a tar file."
         exit 1

--- a/eessi-upload-to-staging
+++ b/eessi-upload-to-staging
@@ -25,7 +25,11 @@ function upload_to_staging_bucket
 
   echo "Attempting to create: https://${bucket}.s3.amazonaws.com/${path}"
   if type -a aws > /dev/null; then
-    aws s3 cp "$file" s3://${bucket}/${path}
+    OPTIONS=""
+    if [ -z "$AWS_ACCESS_KEY_ID"]; then
+      OPTIONS="--no-sign-request"
+    fi
+    aws ${OPTIONS} s3 cp "$file" s3://${bucket}/${path}
   else
   curl -X PUT -T "$file" \
     -H "Host: ${bucket}.s3.amazonaws.com" \

--- a/eessi-upload-to-staging
+++ b/eessi-upload-to-staging
@@ -14,7 +14,7 @@ function upload_to_staging_bucket
   date=$(date +"%a, %d %b %Y %T %z")
   content_type='application/x-compressed-tar'
 
-  acl="x-amz-acl:public-read"
+  acl="x-amz-acl:private"
   string="PUT\n\n${content_type}\n${date}\n${acl}\n/${bucket}/${path}"
   
   if ! [ -z "$AWS_ACCESS_KEY_ID" ]; then
@@ -23,18 +23,18 @@ function upload_to_staging_bucket
     aclstring="-H \"${acl}\""
   fi
 
-  if ! curl --silent -X PUT -T "$file" \
+  echo "Attempting to create: https://${bucket}.s3.amazonaws.com/${path}"
+  if type -a aws > /dev/null; then
+    aws s3 cp "$file" s3://${bucket}/${path}
+  else
+  curl -X PUT -T "$file" \
     -H "Host: ${bucket}.s3.amazonaws.com" \
     -H "Date: ${date}" \
     -H "Content-Type: ${content_type}" \
     $aclstring \
     $authstring \
-    "https://${bucket}.s3.amazonaws.com/${path}" > /dev/null; then
-	echo "https://${bucket}.s3.amazonaws.com/${path}"
-    else
-	echo "Permission denied."
-	exit 1
-    fi
+    "https://${bucket}.s3.amazonaws.com/${path}"
+  fi
 }
 
 # This needs expanding etc.

--- a/static/terraform/output.tf
+++ b/static/terraform/output.tf
@@ -18,3 +18,10 @@ output "monitoring_node_eip" {
   value       = aws_eip.monitoring_node.*.public_dns
 }
 
+output "staging_bucket_url" {
+  value       = aws_s3_bucket.staging_bucket.bucket_domain_name
+}
+
+output "snapshot_bucket_url" {
+  value       = aws_s3_bucket.gentoo_snapshot_bucket.bucket_domain_name
+}


### PR DESCRIPTION
- Give that IAM role the required permissions.
  (upload and list S3 objects in eessi-staging only.)
- Set up that IAM role in the host in question.
- Migrate to using `aws` for file copy.
- Prevent keys from being overwritten. 
- Also adds support for --node-storage to set root volume size in GB.