### PR TITLE
First of a few big patches to clear the way for Atlantis.

### DIFF
--- a/static/cloud-init/atlantis.eessi-hpc.org.yaml
+++ b/static/cloud-init/atlantis.eessi-hpc.org.yaml
@@ -1,0 +1,40 @@
+#cloud-config
+
+# Cloud-init for atalantis.eessi-hpc.org
+
+hostname: atlantis.eessi-hpc.org
+
+yum_repos:
+    epel-release:
+        baseurl: https://download.fedoraproject.org/pub/epel/$releasever/Everything/$basearch
+        metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+        enabled: true
+        failovermethod: priority
+        gpgcheck: true
+        gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+        name: Extra Packages for Enterprise Linux 8 - Release
+    hashicorp:
+        baseurl: https://rpm.releases.hashicorp.com/RHEL/$releasever/$basearch/stable
+        enabled: true
+        gpgcheck: true
+        gpgkey: https://rpm.releases.hashicorp.com/gpg
+        name: Packages from Hashicorp (terraform and friends)
+
+package_upgrade: true
+
+packages:
+  - ansible
+  - awscli
+  - terraform
+  - htop
+  - podman
+  # required for semanage
+  - policycoreutils-python-utils
+  - python38
+  - screen
+  - singularity
+  - tmux
+
+# From where do we copy permissions? Need to look at sealert.
+#runcmd:
+#  - semanage fcontext -a -e /var /persistent

--- a/static/cloud-init/create_rpm_and_deb_repos.sh
+++ b/static/cloud-init/create_rpm_and_deb_repos.sh
@@ -57,7 +57,7 @@ if ! /usr/local/bin/aptly repo show eessi 2>&1 > /dev/null; then
     /usr/local/bin/aptly repo create -distribution=sid -component=main eessi
 fi
 aptly repo add eessi $TMPDIR
-aptly publish repo -skip-signing -architectures="all" eessi 2&>1 > /dev/null || /usr/local/bin/aptly publish repo -skip-signing -architectures="all" eessi sid > /dev/null
+aptly publish repo -skip-signing -architectures="all" eessi 2>&1 > /dev/null || /usr/local/bin/aptly publish repo -skip-signing -architectures="all" eessi sid > /dev/null
 
 cp -ua /root/.aptly/public  /var/www/html/eessi/deb
 

--- a/static/cloud-init/create_rpm_and_deb_repos.sh
+++ b/static/cloud-init/create_rpm_and_deb_repos.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+REPO="https://api.github.com/repos/EESSI/filesystem-layer/releases"
+TMPDIR=$( mktemp -d )
+APTLY="https://github.com/aptly-dev/aptly/releases/download/v1.4.0/aptly_1.4.0_linux_amd64.tar.gz"
+
+RHEL_VERSIONS="8"
+ARCHS="noarch" # x86_64 arm64 ppc64le"
+
+cd $TMPDIR
+
+# bzip2 is required by aptly
+yum -y --quiet install bzip2
+
+# Create repo trees
+# http://url/reponame/rhel/$releasever/$basearch
+for arch in $ARCHS; do
+    mkdir -p /var/www/html/eessi/rhel/8/$arch
+done
+
+mkdir -p /var/www/html/eessi/deb
+
+# We'll use repobuild to build rpm repo.
+yum -y --quiet install createrepo
+
+# We'll use aptly to create the deb repo.
+[ -d /usr/local/bin ] || mkdir -p /usr/local/bin
+if ! [ -f /usr/local/bin/aptly ]; then
+    curl -L -O --silent $APTLY
+    tar xzf aptly_1.4.0_linux_amd64.tar.gz
+    cp aptly_1.4.0_linux_amd64/aptly /usr/local/bin
+    rm -rf aptly*
+fi
+
+mkdir packages;
+cd packages;
+rm -f *
+# Fetch packages from the EESSI github repo
+for url in $( curl --silent $REPO | grep -E 'browser_download_url.*(deb|rpm)' | grep -v latest | cut -f4 -d'"' );
+    do curl -L -O --silent $url ;
+done
+
+# Create yum repo
+for arch in $ARCHS; do
+    cd /var/www/html/eessi/rhel/8/$arch
+    cp -ua $TMPDIR/packages/*${arch}*.rpm .
+    if [ -d repodata ];
+    then
+        createrepo -q --update .;
+    else
+        createrepo .
+    fi
+done
+
+# Create debian repo
+if ! aptly repo show eessi 2>&1 > /dev/null; then
+    aptly repo create -distribution=sid -component=main eessi
+fi
+aptly repo add eessi $TMPDIR
+
+if ! aptly repo show eessi 2>&1 > /dev/null;
+then
+    aptly publish repo -architectures="all" eessi > /dev/null
+else
+    aptly publish update sid > /dev/null
+fi
+cp -ua /root/.aptly/public  /var/www/html/eessi/deb
+
+# rm -rf $TMPDIR

--- a/static/cloud-init/create_rpm_and_deb_repos.sh
+++ b/static/cloud-init/create_rpm_and_deb_repos.sh
@@ -27,9 +27,9 @@ yum -y --quiet install createrepo
 [ -d /usr/local/bin ] || mkdir -p /usr/local/bin
 if ! [ -f /usr/local/bin/aptly ]; then
     curl -L -O --silent $APTLY
-    tar xzf aptly_1.4.0_linux_amd64.tar.gz
-    cp aptly_1.4.0_linux_amd64/aptly /usr/local/bin
-    rm -rf aptly*
+    tar xzf /usr/local/bin/aptly_1.4.0_linux_amd64.tar.gz
+    cp /usr/local/bin/aptly_1.4.0_linux_amd64/aptly /usr/local/bin
+    rm -rf /usr/local/bin/aptly*
 fi
 
 mkdir packages;
@@ -53,11 +53,11 @@ for arch in $ARCHS; do
 done
 
 # Create debian repo
-if ! aptly repo show eessi 2>&1 > /dev/null; then
-    aptly repo create -distribution=sid -component=main eessi
+if ! /usr/local/bin/aptly repo show eessi 2>&1 > /dev/null; then
+    /usr/local/bin/aptly repo create -distribution=sid -component=main eessi
 fi
 aptly repo add eessi $TMPDIR
-aptly publish repo -skip-signing -architectures="all" eessi 2&>1 > /dev/null || aptly publish repo -skip-signing -architectures="all" eessi sid > /dev/null
+aptly publish repo -skip-signing -architectures="all" eessi 2&>1 > /dev/null || /usr/local/bin/aptly publish repo -skip-signing -architectures="all" eessi sid > /dev/null
 
 cp -ua /root/.aptly/public  /var/www/html/eessi/deb
 

--- a/static/cloud-init/create_rpm_and_deb_repos.sh
+++ b/static/cloud-init/create_rpm_and_deb_repos.sh
@@ -57,7 +57,7 @@ if ! aptly repo show eessi 2>&1 > /dev/null; then
     aptly repo create -distribution=sid -component=main eessi
 fi
 aptly repo add eessi $TMPDIR
-aptly publish repo -architectures="all" eessi 2&>1 > /dev/null || aptly publish update sid > /dev/null
+aptly publish repo -skip-signing -architectures="all" eessi 2&>1 > /dev/null || aptly publish repo -skip-signing -architectures="all" eessi sid > /dev/null
 
 cp -ua /root/.aptly/public  /var/www/html/eessi/deb
 

--- a/static/cloud-init/create_rpm_and_deb_repos.sh
+++ b/static/cloud-init/create_rpm_and_deb_repos.sh
@@ -57,13 +57,8 @@ if ! aptly repo show eessi 2>&1 > /dev/null; then
     aptly repo create -distribution=sid -component=main eessi
 fi
 aptly repo add eessi $TMPDIR
+aptly publish repo -architectures="all" eessi 2&>1 > /dev/null || aptly publish update sid > /dev/null
 
-if ! aptly repo show eessi 2>&1 > /dev/null;
-then
-    aptly publish repo -architectures="all" eessi > /dev/null
-else
-    aptly publish update sid > /dev/null
-fi
 cp -ua /root/.aptly/public  /var/www/html/eessi/deb
 
-# rm -rf $TMPDIR
+rm -rf $TMPDIR

--- a/static/cloud-init/repo.eessi-hpc.org.yaml
+++ b/static/cloud-init/repo.eessi-hpc.org.yaml
@@ -29,6 +29,6 @@ packages:
   - httpd
 
 runcmd:
-  # - curl -O -L --quiet
+  - curl -O -L --quiet https://raw.githubusercontent.com/terjekv/infrastructure/reposerver/static/cloud-init/create_rpm_and_deb_repos.sh
   - systemctl enable httpd
   - systemctl start httpd

--- a/static/cloud-init/repo.eessi-hpc.org.yaml
+++ b/static/cloud-init/repo.eessi-hpc.org.yaml
@@ -29,7 +29,7 @@ packages:
   - httpd
 
 runcmd:
-  - curl -o /etc/cron.hourly/repo-update -L --quiet https://raw.githubusercontent.com/terjekv/infrastructure/reposerver/static/cloud-init/create_rpm_and_deb_repos.sh
+  - curl -o /etc/cron.hourly/repo-update -L https://raw.githubusercontent.com/terjekv/infrastructure/reposerver/static/cloud-init/create_rpm_and_deb_repos.sh
   - chmod a+rx /etc/cron.hourly/repo-update
   - semanage fcontext -a -e /etc/cron.hourly/0anacron /etc/cron.hourly/repo-update
   - restorecon -vvRF /etc/cron.hourly/repo-update

--- a/static/cloud-init/repo.eessi-hpc.org.yaml
+++ b/static/cloud-init/repo.eessi-hpc.org.yaml
@@ -29,6 +29,10 @@ packages:
   - httpd
 
 runcmd:
-  - curl -O -L --quiet https://raw.githubusercontent.com/terjekv/infrastructure/reposerver/static/cloud-init/create_rpm_and_deb_repos.sh
+  - curl -o /etc/cron.hourly/repo-update -L --quiet https://raw.githubusercontent.com/terjekv/infrastructure/reposerver/static/cloud-init/create_rpm_and_deb_repos.sh
+  - chmod a+rx /etc/cron.hourly/repo-update
+  - semanage fcontext -a -e /etc/cron.hourly/0anacron /etc/cron.hourly/repo-update
+  - restorecon -vvRF /etc/cron.hourly/repo-update
+  - /etc/cron.hourly/repo-update
   - systemctl enable httpd
   - systemctl start httpd

--- a/static/cloud-init/repo.eessi-hpc.org.yaml
+++ b/static/cloud-init/repo.eessi-hpc.org.yaml
@@ -1,0 +1,34 @@
+#cloud-config
+
+# Cloud-init for repo.eessi-hpc.org
+
+hostname: repo.eessi-hpc.org
+
+yum_repos:
+    epel-release:
+        baseurl: https://download.fedoraproject.org/pub/epel/$releasever/Everything/$basearch
+        metalink: https://mirrors.fedoraproject.org/metalink?repo=epel-$releasever&arch=$basearch&infra=$infra&content=$contentdir
+        enabled: true
+        gpgcheck: true
+        gpgkey: http://download.fedoraproject.org/pub/epel/RPM-GPG-KEY-EPEL-8
+        name: Extra Packages for Enterprise Linux 8 - Release
+
+package_upgrade: true
+
+packages:
+  - ansible
+  - awscli
+  - git
+  - htop
+  # required for semanage
+  - policycoreutils-python-utils
+  - python38
+  - screen
+  - singularity
+  - tmux
+  - httpd
+
+runcmd:
+  # - curl -O -L --quiet
+  - systemctl enable httpd
+  - systemctl start httpd

--- a/static/terraform/atlantis.tf
+++ b/static/terraform/atlantis.tf
@@ -1,0 +1,60 @@
+data "template_file" "atlantis_user_data" {
+  template = file("../cloud-init/atlantis.eessi-hpc.org.yaml")
+}
+
+resource "aws_instance" "atlantis_node" {
+#  depends_on             = [aws_ebs_volume.home_volume]
+
+  ami                    = data.aws_ami.x86_64.id
+  instance_type          = var.instance_terraform
+  vpc_security_group_ids = [aws_security_group.atlantis.id]
+  key_name               = "${var.localuser}-core-deployer-key"
+  monitoring             = true
+  availability_zone      = "eu-west-1a"
+  user_data              = data.template_file.atlantis_user_data.rendered
+
+  root_block_device {
+    volume_size = 20
+  }
+
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
+
+  tags = {
+#    Owner = var.localuser
+    Name = "[CORE] atlantis (terraform)"
+  }
+}
+
+resource "aws_eip" "atlantis_node" {
+  instance = aws_instance.atlantis_node.id
+  vpc      = true
+
+  tags = {
+    Name = "atlantis (terraform)"
+  }
+}
+
+resource "aws_route53_record" "atlantis" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "atlantis.eessi-infra.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.atlantis_node.public_ip]
+}
+resource "aws_route53_record" "atlantis_infra" {
+  zone_id = var.aws_route53_infra_hpc_zoneid
+  name    = "atlantis.infra.eessi-hpc.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.atlantis_node.public_ip]
+}
+
+resource "aws_route53_record" "atlantis_cname_terraform" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "terraform.eessi-infra.org"
+  type    = "CNAME"
+  ttl     = "300"
+  records = ["atlantis.eessi-infra.org"]
+}

--- a/static/terraform/aws_lifecycle_policies.tf
+++ b/static/terraform/aws_lifecycle_policies.tf
@@ -1,0 +1,83 @@
+resource "aws_iam_role" "dlm_lifecycle_role" {
+  name = "dlm-lifecycle-role"
+ 
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "dlm.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+ 
+resource "aws_iam_role_policy" "dlm_lifecycle" {
+  name = "dlm-lifecycle-policy"
+  role = "${aws_iam_role.dlm_lifecycle_role.id}"
+ 
+  policy = <<EOF
+{
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Effect": "Allow",
+         "Action": [
+            "ec2:CreateSnapshot",
+            "ec2:DeleteSnapshot",
+            "ec2:DescribeVolumes",
+            "ec2:DescribeSnapshots"
+         ],
+         "Resource": "*"
+      },
+      {
+         "Effect": "Allow",
+         "Action": [
+            "ec2:CreateTags"
+         ],
+         "Resource": "arn:aws:ec2:*::snapshot/*"
+      }
+   ]
+}
+EOF
+}
+ 
+resource "aws_dlm_lifecycle_policy" "test_lifecyclerole" {
+  description        = "DLM lifecycle policy"
+  execution_role_arn = "${aws_iam_role.dlm_lifecycle_role.arn}"
+  state              = "ENABLED"
+ 
+  policy_details {
+    resource_types = ["VOLUME"]
+ 
+    schedule {
+      name = "2 weeks of daily snapshots"
+ 
+      create_rule {
+        interval      = 24
+        interval_unit = "HOURS"
+        times         = ["23:45"]
+      }
+ 
+      retain_rule {
+        count = 14
+      }
+ 
+      tags_to_add = {
+        SnapshotCreator = "DLM"
+      }
+ 
+      copy_tags = false
+    }
+ 
+    target_tags = {
+      Snapshot = "true"
+    }
+  }
+}

--- a/static/terraform/login.tf
+++ b/static/terraform/login.tf
@@ -24,6 +24,7 @@ resource "aws_instance" "login_node" {
   tags = {
 #    Owner = var.localuser
     Name = "[CORE] login.eessi-hpc.org"
+    Snapshot = "true"
   }
 }
 

--- a/static/terraform/monitoring.tf
+++ b/static/terraform/monitoring.tf
@@ -24,6 +24,7 @@ resource "aws_instance" "monitoring_node" {
   tags = {
 #    Owner = var.localuser
     Name = "[CORE] monitoring.infra.eessi-hpc.org"
+    Snapshot = "true"
   }
 }
 

--- a/static/terraform/output.tf
+++ b/static/terraform/output.tf
@@ -22,6 +22,10 @@ output "repo_node_eip" {
   value       = aws_eip.repo_node.*.public_dns
 }
 
+output "atlantis_node_dns" {
+  value       = aws_eip.atlantis_node.*.public_dns
+}
+
 output "staging_bucket_url" {
   value       = aws_s3_bucket.staging_bucket.bucket_domain_name
 }

--- a/static/terraform/output.tf
+++ b/static/terraform/output.tf
@@ -18,6 +18,10 @@ output "monitoring_node_eip" {
   value       = aws_eip.monitoring_node.*.public_dns
 }
 
+output "repo_node_eip" {
+  value       = aws_eip.repo_node.*.public_dns
+}
+
 output "staging_bucket_url" {
   value       = aws_s3_bucket.staging_bucket.bucket_domain_name
 }

--- a/static/terraform/reposerver.tf
+++ b/static/terraform/reposerver.tf
@@ -1,0 +1,50 @@
+data "template_file" "user_data_repo" {
+  template = file("../cloud-init/repo.eessi-hpc.org.yaml")
+}
+
+resource "aws_instance" "repo_node" {
+  ami                    = data.aws_ami.x86_64.id
+  instance_type          = var.instance_repo
+  vpc_security_group_ids = [aws_security_group.open_web_node.id]
+  key_name               = "${var.localuser}-core-deployer-key"
+  monitoring             = true
+  availability_zone      = "eu-west-1a"
+  user_data              = data.template_file.user_data_repo.rendered
+
+  root_block_device {
+    volume_size = 20
+  }
+
+#  lifecycle {
+#    ignore_changes = [ami, user_data]
+#  }
+
+  tags = {
+#    Owner = var.localuser
+    Name = "[CORE] repo.eessi-hpc.org"
+  }
+}
+
+resource "aws_eip" "repo_node" {
+  instance = aws_instance.repo_node.id
+  vpc      = true
+
+  tags = {
+    Name = "reposerver"
+  }
+}
+
+resource "aws_route53_record" "repo" {
+  zone_id = var.aws_route53_infra_zoneid
+  name    = "repo.eessi-infra.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.repo_node.public_ip]
+}
+resource "aws_route53_record" "repo_infra" {
+  zone_id = var.aws_route53_infra_hpc_zoneid
+  name    = "repo.infra.eessi-hpc.org"
+  type    = "A"
+  ttl     = "300"
+  records = [aws_eip.repo_node.public_ip]
+}

--- a/static/terraform/reposerver.tf
+++ b/static/terraform/reposerver.tf
@@ -15,9 +15,9 @@ resource "aws_instance" "repo_node" {
     volume_size = 20
   }
 
-#  lifecycle {
-#    ignore_changes = [ami, user_data]
-#  }
+  lifecycle {
+    ignore_changes = [ami, user_data]
+  }
 
   tags = {
 #    Owner = var.localuser

--- a/static/terraform/security.tf
+++ b/static/terraform/security.tf
@@ -82,3 +82,36 @@ resource "aws_security_group" "stratum1" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 }
+
+resource "aws_security_group" "atlantis" {
+  name = "atlantis"
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # Atlantis itself
+  ingress {
+    from_port   = 4141
+    to_port     = 4141
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  # SLD testing
+  ingress {
+    from_port   = 5000
+    to_port     = 5000
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}

--- a/static/terraform/stratum1-eu-west.tf
+++ b/static/terraform/stratum1-eu-west.tf
@@ -23,6 +23,7 @@ resource "aws_instance" "stratum1_eu_west" {
   tags = {
 #    Owner = var.localuser
     Name = "[CORE] stratum1-eu-west.eessi-hpc.org"
+    Snapshot = "true"
   }
 }
 

--- a/static/terraform/variables.tf
+++ b/static/terraform/variables.tf
@@ -51,3 +51,7 @@ variable "instance_login" {
 variable "instance_repo" {
     default = "t3.medium"
 }
+
+variable "instance_terraform" {
+    default = "t3.large"
+}

--- a/static/terraform/variables.tf
+++ b/static/terraform/variables.tf
@@ -47,3 +47,7 @@ variable "instance_monitoring" {
 variable "instance_login" {
     default = "t4g.micro"
 }
+
+variable "instance_repo" {
+    default = "t3.medium"
+}


### PR DESCRIPTION
This syncs the current state of the Infrastructure repo with the current state of terraform. This adds:

- The Reposerver node and its dependencies
- The Atlantis (https://www.runatlantis.io) node and its dependencies
- Amazon Data Manager LifeCycle (https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/snapshot-lifecycle.html) to nodes with the appropriate tags.

The goal is to control this deployment neatly when Atlantis becomes operational.